### PR TITLE
Fix typos and inconsistencies across docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ curl https://raw.githubusercontent.com/paradedb/agent-skills/main/SKILL.md >> .w
 curl https://raw.githubusercontent.com/paradedb/agent-skills/main/EXAMPLES.md >> .windsurfrules
 ```
 
-**Note:** Remove the YAML frontmatter (the lines between `---`) from `SKILL.md` when appending to `.windsurfrules`.
+**Note:** Remove the YAML frontmatter (the lines between `---`) from both files when appending to `.windsurfrules`.
 
 </details>
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -13,4 +13,4 @@ For complete and up-to-date ParadeDB documentation, always fetch:
 
 **https://docs.paradedb.com/llms-full.txt**
 
-This contains the full documentation optimized for LLMs. Fetch the current docs before answering ParadeDB questions.
+This contains the full documentation optimized for LLMs. Use `read_web_page` or equivalent to fetch current docs before answering ParadeDB questions.


### PR DESCRIPTION
## Summary
- Fixed extra space before `?` in EXAMPLES.md
- Made `#### Project-Specific Installation` headings consistent across all tool sections in README.md