### PR TITLE
Cache fetched ParadeDB docs for session

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -7,7 +7,7 @@ This document contains example prompts you can use with the ParadeDB skill when 
 For more reviewable answers, prepend this instruction to any prompt:
 
 ```text
-Use ParadeDB docs from https://docs.paradedb.com/llms-full.txt.
+Fetch ParadeDB docs from https://docs.paradedb.com/llms-full.txt once for this session and reuse them unless I ask you to refresh or you need newer/current information.
 Return:
 1) runnable SQL,
 2) a short explanation,
@@ -20,7 +20,15 @@ Return:
 Use this when you want strict behaviour if the docs cannot be fetched:
 
 ```text
-If you cannot fetch live ParadeDB docs, show the exact error and ask whether to continue with local assumptions only.
+If you cannot fetch live ParadeDB docs, show the exact error. If you already fetched them earlier in this session, continue from the cached session copy. Otherwise ask whether to continue with local assumptions only.
+```
+
+## Session Cache Prompt
+
+Use this when you want to force one fetch per conversation unless refreshed:
+
+```text
+If you have not fetched ParadeDB docs in this session yet, fetch https://docs.paradedb.com/llms-full.txt now and cache it for the rest of this session. Reuse that cached copy unless I ask you to refresh it or the answer depends on newer/current changes.
 ```
 
 ## Getting Started & Setup

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 An AI agent skill for [ParadeDB](https://paradedb.com) - Elasticsearch-quality full-text search in Postgres.
 
-This skill uses a pointer-based approach. Instead of bundling static docs that can become stale, it instructs agents to fetch current ParadeDB docs from [https://docs.paradedb.com/llms-full.txt](https://docs.paradedb.com/llms-full.txt) at runtime.
+This skill uses a pointer-based approach. Instead of bundling static docs that can become stale, it instructs agents to fetch current ParadeDB docs from [https://docs.paradedb.com/llms-full.txt](https://docs.paradedb.com/llms-full.txt) at runtime and reuse the first successful fetch for the rest of the session.
 
 > [!NOTE]
 > ParadeDB also supports MCP integrations. For setup instructions, use
@@ -88,9 +88,16 @@ Once installed, the skill activates when you ask your AI agent about:
 - Full-text search in Postgres
 - Elasticsearch alternatives for Postgres
 
-The agent should fetch live docs before answering. If docs are unavailable due
-to network or access errors, the skill requires the agent to report the error
-and ask whether to continue with local context only.
+On the first ParadeDB question in a session, the agent should fetch live docs
+before answering. After a successful fetch, it should reuse that session copy
+for later ParadeDB questions and only refetch when the user asks for a refresh,
+the answer depends on newer/current changes, the earlier fetch was incomplete,
+or the session context is no longer available.
+
+If docs are unavailable due to network or access errors, the skill requires the
+agent to report the error. When a cached session copy exists, the agent should
+say it can continue from that cached copy; otherwise it should ask whether to
+continue with local context only.
 
 ### Example Prompts
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -26,20 +26,39 @@ For complete and up-to-date ParadeDB documentation, always fetch:
 Use your web-fetching tool to retrieve current docs before answering ParadeDB
 questions. Treat behavior claims as version-dependent until verified.
 
+## Documentation Fetch Policy
+
+1. On the first ParadeDB question in a session, fetch `llms-full.txt`.
+2. After a successful fetch, treat that content as cached session context and
+   reuse it for later ParadeDB questions in the same session.
+3. Do not refetch on every turn when the previously fetched docs are still
+   available and relevant.
+4. Refresh the docs only when one of these is true:
+   - the user asks for a refresh or re-fetch
+   - the question depends on very recent/current changes
+   - the needed content was not included in the earlier fetch
+   - session context appears lost, truncated, or unavailable
+   - the earlier fetch failed or looked incomplete
+
 ## Response Guidelines
 
 1. Prefer runnable SQL examples over prose-only answers.
 2. State ParadeDB/Postgres version assumptions when syntax may differ.
-3. If behavior is uncertain, call it out explicitly instead of guessing.
+3. Say when you are relying on cached session docs versus a fresh fetch if that
+   matters to the answer.
+4. If behavior is uncertain, call it out explicitly instead of guessing.
 
 ## Network Failure Rules (Mandatory)
 
 If `llms-full.txt` (or any required docs URL) cannot be fetched due to DNS/network/access errors:
 
 1. State clearly that live docs could not be accessed and include the actual error.
-2. Ask the user whether to proceed with local/repo-only context or to retry later.
-3. Do **not** invent or infer doc URLs, page paths, or feature availability.
-4. Do **not** present unverified links as real.
-5. Label any fallback statements as assumptions and keep them minimal.
+2. If you have cached session docs from an earlier successful fetch, say that
+   you can continue from that cached copy unless the user wants to stop.
+3. If you do not have cached session docs, ask whether to proceed with
+   local/repo-only context or to retry later.
+4. Do **not** invent or infer doc URLs, page paths, or feature availability.
+5. Do **not** present unverified links as real.
+6. Label any fallback statements as assumptions and keep them minimal.
 
 Never silently switch to guessed documentation structure when network access fails.


### PR DESCRIPTION
## Summary
- add explicit session-level caching rules to the ParadeDB skill instructions
- document when agents should refresh fetched docs and how to fall back on cached session docs
- update example prompts to reinforce one fetch per session unless refreshed

## Testing
- git diff --check

Closes #7