### PR TITLE
docs: Update positioning in README and SKILL.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@
 
 # ParadeDB Agent Skill
 
-An AI agent skill for [ParadeDB](https://paradedb.com) - Elasticsearch-quality full-text search, vector retrieval, and aggregations in Postgres. Once installed, the skill activates when you ask your agent about:
+An AI agent skill for [ParadeDB](https://paradedb.com) - One Postgres for your application data, full-text search, vector retrieval, and aggregations.. Once installed, the skill activates when you ask your agent about:
 
 - ParadeDB
 - BM25 indexing

--- a/README.md
+++ b/README.md
@@ -1,6 +1,32 @@
+<h1 align="center">
+  <a href="https://paradedb.com">
+    <picture align=center>
+      <source media="(prefers-color-scheme: dark)" srcset="https://github.com/paradedb/paradedb/raw/main/docs/logo/paradedb-logo-dark-large.svg">
+      <source media="(prefers-color-scheme: light)" srcset="https://github.com/paradedb/paradedb/raw/main/docs/logo/paradedb-logo-light-large.svg">
+      <img alt="The ParadeDB logo." src="https://github.com/paradedb/paradedb/raw/main/docs/logo/paradedb-logo-light-large.svg">
+    </picture>
+  </a>
+  <br>
+</h1>
+
+<p align="center">
+  <b>Search without a second system.</b><br/>
+  One Postgres for your application data, full-text search, vector retrieval, and aggregations.
+</p>
+
+<h3 align="center">
+  <a href="https://paradedb.com">Website</a> &bull;
+  <a href="https://docs.paradedb.com">Docs</a> &bull;
+  <a href="https://paradedb.com/slack">Community</a> &bull;
+  <a href="https://paradedb.com/blog/">Blog</a> &bull;
+  <a href="https://docs.paradedb.com/changelog/">Changelog</a>
+</h3>
+
+---
+
 # ParadeDB Agent Skill
 
-An AI agent skill for [ParadeDB](https://paradedb.com) - Elasticsearch-quality full-text search in Postgres. Once installed, the skill activates when you ask your agent about:
+An AI agent skill for [ParadeDB](https://paradedb.com) - Elasticsearch-quality full-text search, vector retrieval, and aggregations in Postgres. Once installed, the skill activates when you ask your agent about:
 
 - ParadeDB
 - BM25 indexing

--- a/SKILL.md
+++ b/SKILL.md
@@ -9,8 +9,8 @@ description: >
 
 # ParadeDB Skill
 
-ParadeDB brings Elasticsearch-quality full-text search and analytics to
-Postgres via the `pg_search` extension.
+ParadeDB adds Elasticsearch-quality full-text search, vector retrieval, and
+aggregations to Postgres via the `pg_search` extension.
 
 Use this skill when users ask about:
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -9,8 +9,7 @@ description: >
 
 # ParadeDB Skill
 
-ParadeDB adds Elasticsearch-quality full-text search, vector retrieval, and
-aggregations to Postgres via the `pg_search` extension.
+ParadeDB is one Postgres that unifies your application data, full-text search, vector retrieval, and aggregations via the `pg_search` extension.
 
 Use this skill when users ask about:
 


### PR DESCRIPTION
Updates positioning to match paradedb/paradedb#5483: "Search without a second system." tagline, one-Postgres sub-line, new light/dark logos, and the "full-text search, vector retrieval, and aggregations" framing.

Also adds the branded README header (logo, tagline, nav links), which this repo did not have. Skill frontmatter (used for activation matching) is untouched.