### PR TITLE
docs: Cover vector, hybrid, joins and ORM queries in the skill

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -9,19 +9,172 @@ What are the ways to index large datasets for search using ParadeDB?
 
 What's the quickest way to create a full-text searchable table?
 
-How do I generate embeddings for my documents and store them as pgvector columns?
+How do I load an existing Postgres table into ParadeDB and keep it in sync?
+
+Which Postgres settings should I change before running ParadeDB in production?
+```
+
+## Indexing
+
+```text
+Create a BM25 index for full-text search on my products table
+
+How do I index a JSON column so I can search and filter on nested fields?
+
+How do I index a text array column?
+
+How do I index the output of an expression, like lower(title) or a concatenation of two columns?
+
+My table has more than 32 columns I want to search. How do I index them?
+
+How do I create a partial index that only covers rows where status = 'published'?
+
+When should I enable columnar storage on a field?
+
+How do I reindex without taking search offline, and how do I verify index integrity afterwards?
 ```
 
 ## Basic Full-Text Search
 
 ```text
-Create a BM25 index for full-text search on my products table
-
 How do I implement fuzzy search with ParadeDB?
 
 Write a ParadeDB query to search across multiple text fields
 
 How do I add phrase queries to my BM25 search?
+
+What's the difference between a match query and a term query, and when should I use each?
+
+How do I highlight the matching part of a document in my search results?
+```
+
+## Advanced Query Types
+
+```text
+How do I run a regex query over a text field, and can I do regex inside a phrase?
+
+How do I build a "more like this" query to find documents similar to a given row?
+
+How do I write a proximity query that matches two terms within N tokens of each other?
+
+How do I implement search-as-you-type with a phrase prefix query?
+
+How do I search a range column, e.g. find all rows whose validity range contains a given date?
+
+Can I accept raw user query strings with AND/OR/NOT syntax, and what are the risks?
+
+How do I combine several ParadeDB queries with boolean logic?
+```
+
+## Filtering
+
+```text
+How do I combine a full-text search with filters on numeric, boolean, and timestamp columns?
+
+Why is my filter not being pushed down into the ParadeDB index, and how do I confirm with EXPLAIN?
+
+How do I filter on a field whose values are case-sensitive when the default tokenizer lowercases everything?
+```
+
+## Vector Search
+
+> Native vector search inside the ParadeDB index is a beta feature in `0.25.0` and above.
+> ParadeDB uses pgvector's `vector` type, but its own SPANN-style index — not pgvector's HNSW or IVFFlat.
+
+```text
+How do I add a vector column to my ParadeDB index and run nearest-neighbour search?
+
+Which distance operator do I use, and how does it have to match the operator class I indexed with?
+
+How do I run a nearest-neighbour search restricted to rows that match a filter, in a single index scan?
+
+How do I check with EXPLAIN that my vector query is using TopKScanExecState instead of a brute-force sort?
+
+My vector results change between runs. How do I make the ordering deterministic?
+
+How do I tune paradedb.vector_cluster_max_probe to trade recall against latency?
+
+What do centroid_ratio, training_samples_per_centroid, and cluster_replication do at index build time?
+
+Should I migrate off pgvector's HNSW index, and what do I gain for filtered queries?
+
+How do I generate embeddings for my documents and store them in a column ParadeDB can index?
+```
+
+## Hybrid Search
+
+```text
+How do I set up a hybrid search that fuses BM25 and vector results with reciprocal rank fusion?
+
+Why can't I just add the BM25 score and the vector distance together?
+
+How do I weight the text branch more heavily than the vector branch in my RRF query?
+
+What rank constant (k) should I use for RRF, and how does it change the results?
+
+How do I run nearest-neighbour search and combine it with text search for hybrid results?
+```
+
+## Joins
+
+```text
+How do I search across a joined table and still get the search pushed into the index?
+
+What are the requirements for join pushdown in ParadeDB?
+
+How do I write a semi join that returns parent rows having at least one matching child row?
+
+How do I score a query that spans two tables?
+```
+
+## Analytics & Aggregations
+
+```text
+How do I implement category facets with counts for my e-commerce search results?
+
+Write a ParadeDB query that returns faceted counts for brand, price range, and category
+
+How do I build a filter sidebar with dynamic facet counts that update as users apply filters?
+
+How do I add range aggregations for numeric fields, such as price?
+
+How do I bucket search results into a date histogram by month?
+
+How do I compute percentiles, cardinality, and stats over the rows matching a search?
+
+How do I return the top hits within each bucket of a terms aggregation?
+
+What are the limitations of ParadeDB aggregations, and how do I make them faster?
+```
+
+## Ranking & Relevance Tuning
+
+```text
+How do I configure BM25 field weights to prioritize title matches over description matches?
+
+How do I add boost fields to prioritize certain matches?
+
+How do I read pdb.score() and sort by relevance alongside another column?
+
+How do I keep the Top K optimization when I sort by score and then by a tiebreaker column?
+```
+
+## Tokenizers & Token Filters
+
+```text
+What tokenizers are available in ParadeDB, and how do I configure them?
+
+How do I set up ngram tokenization for partial matching and autocomplete?
+
+How do I index Chinese, Japanese, or Korean text?
+
+How do I apply stemming and stopword removal to one field but not another?
+
+How do I make accented text match unaccented queries?
+
+How do I index identifiers and code with a tokenizer that keeps snake_case and camelCase parts searchable?
+
+Can one field have several tokenizers, and how do I choose which one a query uses?
 ```
 
 ## Handling No Results & Fallback Strategies
@@ -34,18 +187,20 @@ How do I implement a fallback from BM25 to vector search when there are no match
 How do I configure fuzzy matching as a fallback when exact queries fail?
 ```
 
-## Advanced Search Features
+## Application & ORM Integration
 
 ```text
-Write a ParadeDB query with faceted search and aggregations
+How do I define a ParadeDB index and run searches from Drizzle?
 
-How do I run nearest neighbour search and combine it with text search for hybrid results?
+How do I use ParadeDB from Django without dropping to raw SQL?
 
-How do I set up a hybrid search that fuses BM25 and vector scores?
+Show me the SQLAlchemy equivalent of this ParadeDB query
 
-How do I add boost fields to prioritize certain matches?
+How do I add ParadeDB search to an ActiveRecord model in Rails?
 
-What tokenizers are available in ParadeDB, and how do I configure them?
+How do I call ParadeDB search and vector search from EF Core?
+
+How do I paginate search results without the offset getting slow?
 ```
 
 ## Migration & Integration
@@ -61,29 +216,37 @@ Translate this Elasticsearch query to ParadeDB SQL:
   }
 }
 
+Which Elasticsearch features have a ParadeDB equivalent, and which don't?
+
 Can ParadeDB coexist with other PostgreSQL extensions?
+
+How do I run ParadeDB alongside Citus?
 ```
 
 ## Performance & Optimization
 
 ```text
-How do I configure BM25 field weights to prioritize title matches over description matches?
-
-How do I set up ngram tokenization for partial matching and autocomplete?
-
 What are the best practices for scaling ParadeDB in production?
 
 How do I monitor and tune ParadeDB performance?
+
+How do I speed up index creation on a large table?
+
+My write throughput dropped after adding a ParadeDB index. What should I tune?
+
+How do I increase read throughput for a search-heavy workload?
 ```
 
-## Analytics & Aggregations
+## Operations & Deployment
 
 ```text
-How do I implement category facets with counts for my e-commerce search results?
+How do I deploy ParadeDB on Kubernetes with high availability?
 
-Write a ParadeDB query that returns faceted counts for brand, price range, and category
+How do I set up logical replication from my primary Postgres into ParadeDB?
 
-How do I build a filter sidebar with dynamic facet counts that update as users apply filters?
+How do I handle schema changes on the publisher once logical replication is running?
 
-How do I add range aggregations for numeric fields, such as price?
+How do I upgrade ParadeDB safely, and what do I need to do to my indexes?
+
+How do I run ParadeDB in CI with GitHub Actions or GitLab CI?
 ```

--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -92,7 +92,7 @@ How do I check with EXPLAIN that my vector query is using TopKScanExecState inst
 
 My vector results change between runs. How do I make the ordering deterministic?
 
-How do I tune paradedb.vector_cluster_max_probe to trade recall against latency?
+How do I tune Paradedb to trade recall against latency?
 
 What do centroid_ratio, training_samples_per_centroid, and cluster_replication do at index build time?
 

--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -17,7 +17,7 @@ Which Postgres settings should I change before running ParadeDB in production?
 ## Indexing
 
 ```text
-Create a BM25 index for full-text search on my products table
+Create a ParadeDB index for full-text search on my products table
 
 How do I index a JSON column so I can search and filter on nested fields?
 
@@ -41,7 +41,7 @@ How do I implement fuzzy search with ParadeDB?
 
 Write a ParadeDB query to search across multiple text fields
 
-How do I add phrase queries to my BM25 search?
+How do I add phrase queries to my full-text search?
 
 What's the difference between a match query and a term query, and when should I use each?
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@
 An AI agent skill for [ParadeDB](https://paradedb.com) - One Postgres for your application data, full-text search, vector retrieval, and aggregations.. Once installed, the skill activates when you ask your agent about:
 
 - ParadeDB
-- BM25 indexing
+- ParadeDB indexing and BM25 scoring
 - Full-text search in Postgres
 - Vector and hybrid search in Postgres
 - Elasticsearch alternatives for Postgres

--- a/README.md
+++ b/README.md
@@ -31,11 +31,12 @@ An AI agent skill for [ParadeDB](https://paradedb.com) - One Postgres for your a
 - ParadeDB
 - BM25 indexing
 - Full-text search in Postgres
+- Vector and hybrid search in Postgres
 - Elasticsearch alternatives for Postgres
 
 > [!NOTE]
 > ParadeDB also supports MCP integrations. For setup instructions, use
-> [https://docs.paradedb.com/welcome/ai-agents](https://docs.paradedb.com/welcome/ai-agents).
+> [https://docs.paradedb.com/documentation/getting-started/ai-agents](https://docs.paradedb.com/documentation/getting-started/ai-agents).
 > The `/mcp` route is a protocol endpoint, not a human-readable docs page.
 
 ## Installation
@@ -109,7 +110,7 @@ See [EXAMPLES.md](EXAMPLES.md) for categorized prompt examples.
 ## Links
 
 - [ParadeDB Documentation](https://docs.paradedb.com)
-- [ParadeDB AI Agents Guide](https://docs.paradedb.com/welcome/ai-agents)
+- [ParadeDB AI Agents Guide](https://docs.paradedb.com/documentation/getting-started/ai-agents)
 - [LLM-Optimized Docs](https://docs.paradedb.com/llms-full.txt)
 - [ParadeDB GitHub](https://github.com/paradedb/paradedb)
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -54,7 +54,12 @@ Do **not** use any tool other than `scripts/paradedb-docs` to fetch documentatio
 4. Do not generate any of the deprecated syntax. The new syntax was released in
    version 0.20.0 and should be used exclusively unless the user requests the old syntax.
    If a query contains `paradedb`, it is using the old syntax. Use `pdb` instead.
-5. Vector search runs inside the ParadeDB index as of version 0.25.0, where it is a beta
+5. In version 0.25.0, the BM25 index was renamed to the ParadeDB index, because it now
+   powers vector search, aggregates, top K and filtering as well as BM25 scoring. Write
+   `CREATE INDEX ... USING paradedb`, not `USING bm25`, which survives only as a
+   backwards-compatible alias, and call it the ParadeDB index. Reserve "BM25" for the
+   scoring function itself.
+6. Vector search runs inside the ParadeDB index as of version 0.25.0, where it is a beta
    feature. ParadeDB indexes pgvector's `vector` type, but does not use pgvector's HNSW or
    IVFFlat indexes — do not suggest them for a vector column that is in a ParadeDB index.
    Fetch `documentation/indexing/indexing-vectors.md` and `documentation/vector/querying.md`

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: paradedb-skill
 description: >
-  Expert guidance on ParadeDB full-text search, hybrid search (BM25 + semantic),
-  aggregations, and analytics in Postgres. Use when writing ParadeDB queries,
-  creating BM25 indexes, configuring tokenizers, or implementing
-  Elasticsearch-quality search in Postgres.
+  Expert guidance on ParadeDB full-text search, vector search, hybrid search
+  (BM25 + semantic), aggregations, and analytics in Postgres. Use when writing
+  ParadeDB queries, creating ParadeDB indexes, indexing vectors, configuring
+  tokenizers, or implementing Elasticsearch-quality search in Postgres.
 ---
 
 # ParadeDB Skill
@@ -13,10 +13,10 @@ ParadeDB is one Postgres that unifies your application data, full-text search, v
 
 Use this skill when users ask about:
 
-- BM25 indexes and relevance ranking
-- Hybrid search (keyword + semantic vectors via `pgvector`)
-- Tokenizers, analyzers, fuzzy matching, and phrase queries
-- Facets, aggregations, snippets/highlighting, and query tuning
+- ParadeDB indexes, BM25 scoring, and relevance ranking
+- Vector search and hybrid search (keyword + semantic, fused with reciprocal rank fusion)
+- Tokenizers, token filters, fuzzy matching, and phrase queries
+- Facets, aggregations, snippets/highlighting, joins, and query tuning
 
 For up-to-date ParadeDB documentation, always fetch the documentation index
 (`llms.txt`) using the bundled script at `scripts/paradedb-docs`.
@@ -54,6 +54,11 @@ Do **not** use any tool other than `scripts/paradedb-docs` to fetch documentatio
 4. Do not generate any of the deprecated syntax. The new syntax was released in
    version 0.20.0 and should be used exclusively unless the user requests the old syntax.
    If a query contains `paradedb`, it is using the old syntax. Use `pdb` instead.
+5. Vector search runs inside the ParadeDB index as of version 0.25.0, where it is a beta
+   feature. ParadeDB indexes pgvector's `vector` type, but does not use pgvector's HNSW or
+   IVFFlat indexes — do not suggest them for a vector column that is in a ParadeDB index.
+   Fetch `documentation/indexing/indexing-vectors.md` and `documentation/vector/querying.md`
+   before writing vector queries, and `documentation/hybrid/rrf.md` before writing hybrid ones.
 
 ## Network Failure Rules (Mandatory)
 


### PR DESCRIPTION
## What

Brings the skill up to date with the docs, which now cover native vector search (`0.25.0`, beta), hybrid search via RRF, joins, and the ORM integrations. Also picks up the 0.25.0 rename of the BM25 index to the ParadeDB index.

`EXAMPLES.md`:

- New sections: Indexing, Advanced Query Types, Filtering, Vector Search, Hybrid Search, Joins, Ranking & Relevance Tuning, Application & ORM Integration, Operations & Deployment.
- Existing sections extended: tokenizers (CJK, source code, multiple per field), aggregations (date histogram, percentiles, cardinality, top hits), performance (index build, read/write throughput), migration (Elasticsearch feature comparison, Citus).
- Dropped the "store them as pgvector columns" framing — vectors now go in the ParadeDB index, and pgvector only supplies the type.

`SKILL.md`:

- Frontmatter description and trigger bullets mention vector search, RRF and joins, so the skill activates on those questions.
- New response guideline on the index rename: write `USING paradedb`, not the `USING bm25` alias, and reserve BM25 for the scoring function.
- New response guideline: vector search is in-index as of `0.25.0`, ParadeDB indexes pgvector's `vector` type but does not use HNSW or IVFFlat, and the vector/hybrid pages should be fetched before writing those queries. Agents otherwise default to `CREATE INDEX ... USING hnsw` from pretraining.

`README.md`: `docs.paradedb.com/welcome/ai-agents` 404s in both places it appears; the page is at `documentation/getting-started/ai-agents`.

## Testing

Prompts were written against the current docs pages, not from memory. Both ai-agents URLs checked with `curl` (404 before, 200 after).

https://claude.ai/code/session_011hnrEwUFJhFzn9pWs3Fe5L